### PR TITLE
Fixing python 3.12 support

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,6 +10,6 @@ repos:
     -   id: check-added-large-files
 
 -   repo: https://github.com/psf/black
-    rev: 22.1.0
+    rev: 23.12.1
     hooks:
       - id: black

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,3 +13,10 @@ repos:
     rev: 23.12.1
     hooks:
       - id: black
+
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  rev: v0.1.11
+  hooks:
+    - id: ruff
+      args: [ --fix ]
+    - id: ruff-format

--- a/pytest_diff_selector/main.py
+++ b/pytest_diff_selector/main.py
@@ -85,9 +85,15 @@ def get_diff(git_repo_directory, git_selection) -> Dict[str, set]:
         for hunk in f:
             hunk: Hunk
             removed = {
-                l.source_line_no for l in hunk if l.line_type == LINE_TYPE_REMOVED
+                line.source_line_no
+                for line in hunk
+                if line.line_type == LINE_TYPE_REMOVED
             }
-            added = {l.target_line_no for l in hunk if l.line_type == LINE_TYPE_ADDED}
+            added = {
+                line.target_line_no
+                for line in hunk
+                if line.line_type == LINE_TYPE_ADDED
+            }
             changed_lines[f.path] = changed_lines[f.path].union(removed, added)
 
     return changed_lines

--- a/pytest_diff_selector/main.py
+++ b/pytest_diff_selector/main.py
@@ -23,6 +23,14 @@ class CollectionVisitor(CallGraphVisitor):
         self.defines_edges = defaultdict(list)
         super().process()
 
+    def analyze_comprehension(self, *args, **kwargs):
+        # since https://peps.python.org/pep-0709/ introduce in python 3.12
+        # we don't comprehension in scope, so we can ignore this logic
+        # locals of comprehension would be available on the parent scope
+        # and that should be sufficient of this code usage
+        if sys.version_info < (3, 12):
+            super().analyze_comprehension(*args, **kwargs)
+
     def visit_FunctionDef(self, node):
         super().visit_FunctionDef(node)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,7 +50,7 @@ test=pytest
 
 [options.entry_points]
 console_scripts =
-    selector = pytest_diff_selector.main:run
+    selector = pytest_diff_selector.main:main
 
 [options.extras_require]
 test =

--- a/tests/test_cmd.py
+++ b/tests/test_cmd.py
@@ -300,3 +300,22 @@ def test_find_change_in_inherited_class_tests(test_repo):
         "test_a.py::TestSomething::test_method_C",
         "test_a.py::TestSomething::test_method",
     } == ret
+
+
+def test_usage_of_list_comprehension(test_repo):
+    write_file(
+        test_repo,
+        "test_b.py",
+        """
+        def test_func1():
+            l = [ i for i in range(10) ]
+            s = { i for i in range(10) }
+            call_something()
+            assert False
+    """,
+    )
+    test_repo.run("git add *.py")
+
+    ret = run(git_diff="HEAD", root_path=test_repo.workspace)
+
+    assert {"test_b.py::test_func1"} == ret


### PR DESCRIPTION
PEP-0709 has remove comprehension scopes
and we should ignore them as well

Ref: https://peps.python.org/pep-0709/
Ref: https://github.com/Technologicat/pyan/issues/93